### PR TITLE
Collapse build-spec to a single MONOREPO ref

### DIFF
--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "f35255190e9b5f007c3033d61e53d4cf3dc64cdb"
+      "git_hash": "004e326118b61e568df21aa80756b50e2712597d"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "698e0650c5f3827a305c9e0aa3900f5c5f291161"
+      "git_hash": "454958063815a1dfa713a52674111249bfcd41ad"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,15 +3,15 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "69f7ac6063a5b31e738d2d7c9a2702923eecbd75"
+      "git_hash": "b8bb72ce62b18069c65092ba9004bee6e92f669e"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "c55585fb3c2e3c281d911bd45a0fe4e4ff3173a5"
+      "git_hash": "49f3335020ae7a19d9713a9cad273d446195c979"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "87bfe5808fc26542b27d3b10a6a626fc060e6fda"
+      "git_hash": "1e79eebc47e84b6b60451bd1b61dd5a05c6ad3db"
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "0af3ad5ad479b5c5486f4c63291adc7458eeb30f"
+      "git_hash": "d4838ca93815ca8aa8d8be821bb36ba1e468ba7c"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "fde05e046526920d0bebc06675b9573e3007f29b"
+      "git_hash": "12985c74b699d1ae02b1fd468573cf1b0b080868"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -24,6 +24,10 @@
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
       "git_hash": "ALS-5375"
+    },{
+      "project_name": "PIC-SURE Dictionary ETL",
+      "project_job_git_key":"DICTIONARY-ETL",
+      "git_hash": "ALS-6816"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -23,7 +23,7 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "ALS-6816"
+      "git_hash": "ALS-5375"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "b8bb72ce62b18069c65092ba9004bee6e92f669e"
+      "git_hash": "13a6b81a64517beccc90ff8a7e20ac36668402e0"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -23,7 +23,7 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "release"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "b87a436614f5c3c3bfada51baa8a50d7460dacb7"
+      "git_hash": "a4524b72105dcafceaac41f1d5bcce75e2e5f5fd"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "660b59956c80d66a8dd19beeed1a0dad017c1a8b"
+      "git_hash": "a19625d81bc09b22971554594ae893f871613d04"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "13a6b81a64517beccc90ff8a7e20ac36668402e0"
+      "git_hash": "255307c639b9d2e19ec548e29e6bbb27fac5143b"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,23 +3,23 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "feature/visualization-resource"
+      "git_hash": "master"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "c55102760f91727bde501ca8f6cdd3117165ea19"
+      "git_hash": "master"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "5ee1a60f47a75013b489eedf7c8dd03bc6e514a4"
+      "git_hash": "master"
     },{
-      "project_name": "PIC-SURE-HPDS-UI Build",
+      "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "30d1144e7e80728c4a7e947b68a76e6e3b2729b7"
+      "git_hash": "master"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "19b580548b9f80a794e6e24cbaecae1f9f846d1a"
+      "git_hash": "test-migration"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "1d95752ca3447d47d30ec1991df746de51758705"
+      "git_hash": "fd0fb5acbb3d57b245300e587bd0cf16243ee13d"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,11 +3,11 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "0e923da9b5428e4214b1f7b8d6f5b5232c72e785"
+      "git_hash": "682401d96b15803140259af691528c933444bf8a"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "0cea58ac3206b0acb414a8098dc3a134b4849b02"
+      "git_hash": "1885753b1cec7ed0239d3dd75c7a3ee980d7a969"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "3fe1a5a57f9c0aafc907f8aae068e2ceb773bccb"
+      "git_hash": "f5a247ae7369dafbd75024f80caedd4bb6be559b"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",
-      "git_hash": "release"
+      "git_hash": "ALS-7709"
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "a0a2f4f383ecaf65772f2513858c494f4271dd5b"
+      "git_hash": "f0f54d2763740c5158de926ce04b3f3c539a664b"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "fbd9be7ec1237085033cf19c40de80697344e44a"
+      "git_hash": "1e670fe0b9ff6b47032a44bce8d7966ae8a79c00"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,15 +11,15 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "release"
+      "git_hash": "ALS-6103-Architectural-Changes-To-Support-Multiple-Auth-providers"
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "ALS-6100"
+      "git_hash": "ALS-6103"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "ALS-6100"
+      "git_hash": "ALS-6103"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "f5a247ae7369dafbd75024f80caedd4bb6be559b"
+      "git_hash": "698e0650c5f3827a305c9e0aa3900f5c5f291161"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "v2.6.1"
+      "git_hash": "ALS-6100"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "0ec4478c999219c5b4a25aff913a96d7e3826eb3"
+      "git_hash": "2773f1767b7a26f4ebaed0db00b42f8e183808ab"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -27,7 +27,7 @@
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "main"
+      "git_hash": "Generate-Ideal-Ingest-CSV"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "39684fd3113f02d3c92b9360cfc9f0daba7c4290"
+      "git_hash": "ba379f42c61b7cd516196b3fb138c1e52ebfe454"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "genomic-v2"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
@@ -19,7 +19,7 @@
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",
-      "git_hash": "ALS-7709"
+      "git_hash": "release"
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "9c759024838b3cdb118ff4559c9a0a8844e1b3f2"
+      "git_hash": "6139a570752b17c2b9fcc5b08d7d0cf7fb371008"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -27,7 +27,7 @@
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "main"
+      "git_hash": "ALS-8903"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,11 +15,11 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "a9bb7feb94d499d7f83f03eac6f10b23e37a6ccc"
+      "git_hash": "6a0467b61af4cb8e543edac247c18f8ec281fce0"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "7b229a82777fc109651ddde99cf9fc565a8ad868"
+      "git_hash": "d4838ca93815ca8aa8d8be821bb36ba1e468ba7c"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "64cccb8511aa2d6fa8b977774c64ddf063e840ea"
+      "git_hash": "d7f4cc4c5d08f08f28ee6e846e67abe8f9315d2e"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "3ea6f866681f9926e0c32572cbf12d72a9943cf2"
+      "git_hash": "212ca22bf29effb306349596b5d15c4aaef29734"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "004e326118b61e568df21aa80756b50e2712597d"
+      "git_hash": "2d65cbe30325ab25c52d19f9fe96179fec7147a0"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
@@ -15,12 +15,11 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "6a0467b61af4cb8e543edac247c18f8ec281fce0"
       "git_hash": "a9bb7feb94d499d7f83f03eac6f10b23e37a6ccc"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "7b229a82777fc109651ddde99cf9fc565a8ad868"
+      "git_hash": "a36e8bc84abc06241a85e18a49ac1ceba512bcb5"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",
-      "git_hash": "release"
+      "git_hash": "ALS-7060"
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "a19625d81bc09b22971554594ae893f871613d04"
+      "git_hash": "7141aff314512bc927e971c0d4a9ce90d0be6aa1"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "e33a7807be69175012ad161ea4da3bee2ae8928a"
+      "git_hash": "17673728d47c2f3ef2c9e6e7d1c7532a0ac0c3d1"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "dcf20aadc499f7536b9f60fb6e1ddfcbede4b68f"
+      "git_hash": "9b45e324c39b446f5c7eb710d32316f4ba02b56c"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "30d1144e7e80728c4a7e947b68a76e6e3b2729b7"
+      "git_hash": "3ea6f866681f9926e0c32572cbf12d72a9943cf2"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "main"
+      "git_hash": "Facet_Loader"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,23 +3,23 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "release/0006"
+      "git_hash": "v2.6.1"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "release/0005"
+      "git_hash": "v2.2.0"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "release/0002"
+      "git_hash": "v2.0.0"
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "ALS-5138-Banner-Improvements"
+      "git_hash": "v2.6.1"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "release/0001"
+      "git_hash": "v2.0.1"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -27,7 +27,7 @@
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "main"
+      "git_hash": "Facet_Loader"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "ALS-8227"
+      "git_hash": "ALS-8712"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "255307c639b9d2e19ec548e29e6bbb27fac5143b"
+      "git_hash": "8b1161437d973138cbb63bf298ef175fe79cf182"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "genomic-v2"
+      "git_hash": "Dockerize-Maven-Install"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "17673728d47c2f3ef2c9e6e7d1c7532a0ac0c3d1"
+      "git_hash": "b57a1759f45008749e06d3ba15f45e55b5b32ae1"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "6a0467b61af4cb8e543edac247c18f8ec281fce0"
+      "git_hash": "a9bb7feb94d499d7f83f03eac6f10b23e37a6ccc"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,11 +3,11 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "682401d96b15803140259af691528c933444bf8a"
+      "git_hash": "0e923da9b5428e4214b1f7b8d6f5b5232c72e785"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "61f34b4d55f843621f87877ef1c0b852a0175d15"
+      "git_hash": "0cea58ac3206b0acb414a8098dc3a134b4849b02"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "662df320cf9126d3b7501309f562a3218f7773da"
+      "git_hash": "c9614c46bbcd06d44294cd1dbd75d3ca670987b6"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "Update-WildFly"
+      "git_hash": "release"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "8b1161437d973138cbb63bf298ef175fe79cf182"
+      "git_hash": "5a3350f9fc4651c871375de3980bb4eea5a3169a"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,23 +3,23 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "f35255190e9b5f007c3033d61e53d4cf3dc64cdb"
+      "git_hash": "da6c12b456d85b4a8ba621d2baf7c0474ce3f225"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "c55102760f91727bde501ca8f6cdd3117165ea19"
+      "git_hash": "1885753b1cec7ed0239d3dd75c7a3ee980d7a969"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "5ee1a60f47a75013b489eedf7c8dd03bc6e514a4"
+      "git_hash": "66f511ad144a2d991d2f6511f5f6539ac9aadcfd"
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "b8f0af6de495333bb5f4f9ff94fa378cc8afc14e"
+      "git_hash": "7141aff314512bc927e971c0d4a9ce90d0be6aa1"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "a9a8c47ff7f020b166a55828a5559eb3bf3ae450"
+      "git_hash": "d4838ca93815ca8aa8d8be821bb36ba1e468ba7c"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "2773f1767b7a26f4ebaed0db00b42f8e183808ab"
+      "git_hash": "d44bf0674f4ec041fcaae62fbe496f006327cf37"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "50c2471d82333601a6af12ca3610774892bea42f"
+      "git_hash": "fbd9be7ec1237085033cf19c40de80697344e44a"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "6139a570752b17c2b9fcc5b08d7d0cf7fb371008"
+      "git_hash": "2d65cbe30325ab25c52d19f9fe96179fec7147a0"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "release"
+      "git_hash": "ALS-5375"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "v2.19.1"
+      "git_hash": "release"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "d4838ca93815ca8aa8d8be821bb36ba1e468ba7c"
+      "git_hash": "44369ab4aefe424a844c90e75a6b5cd8fe198f67"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",
-      "git_hash": "main"
+      "git_hash": "ALS-5375-Dictionary-Resource"
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",

--- a/build-spec.json
+++ b/build-spec.json
@@ -23,7 +23,7 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "fix-all-in-one-dictionary-db"
+      "git_hash": "release"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "0c0ecfb07827247ced9fa26cc2d998c64e1ab14a"
+      "git_hash": "39684fd3113f02d3c92b9360cfc9f0daba7c4290"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "v2.0.1"
+      "git_hash": "master"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "592c5348444be3b257a7d95589fc986ec2d8aa89"
+      "git_hash": "fde05e046526920d0bebc06675b9573e3007f29b"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "ALS-6103-Architectural-Changes-To-Support-Multiple-Auth-providers"
+      "git_hash": "ALS-6103"
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "25896ccd22931b1aeb3083b818356d220c47dbb9"
+      "git_hash": "f2e5b4378754a0ab83c4104844df07e4f21abbb9"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "a06eee0a99a9b3267cad5cbb864ee0f6be299348"
+      "git_hash": "0628c770a1bd87ed40a2ba32667524f2af8c4c44"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "a82637ba9c9d546e25344f75db76467e5b91f339"
+      "git_hash": "0628c770a1bd87ed40a2ba32667524f2af8c4c44"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "v2.6.0"
+      "git_hash": "ALS-6816"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "a0a2f4f383ecaf65772f2513858c494f4271dd5b"
+      "git_hash": "59785065167edd60e666ad258357b46d05265a5f"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "c55102760f91727bde501ca8f6cdd3117165ea19"
+      "git_hash": "592c5348444be3b257a7d95589fc986ec2d8aa89"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "master"
+      "git_hash": "ALS-6100"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "44369ab4aefe424a844c90e75a6b5cd8fe198f67"
+      "git_hash": "d4838ca93815ca8aa8d8be821bb36ba1e468ba7c"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,11 +15,11 @@
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "release"
+      "git_hash": "ALS-6103"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "ALS-6103"
+      "git_hash": "release"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "31fedc4701994ff674b3eba50cd385132515c109"
+      "git_hash": "ALS_4547_Security_findings"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,15 +3,15 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "da6c12b456d85b4a8ba621d2baf7c0474ce3f225"
+      "git_hash": "f35255190e9b5f007c3033d61e53d4cf3dc64cdb"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "1885753b1cec7ed0239d3dd75c7a3ee980d7a969"
+      "git_hash": "c55102760f91727bde501ca8f6cdd3117165ea19"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "66f511ad144a2d991d2f6511f5f6539ac9aadcfd"
+      "git_hash": "5ee1a60f47a75013b489eedf7c8dd03bc6e514a4"
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "ALS-6103"
+      "git_hash": "release"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "2d65cbe30325ab25c52d19f9fe96179fec7147a0"
+      "git_hash": "004e326118b61e568df21aa80756b50e2712597d"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,23 +3,23 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "df5e128f140db7b05a0c8c1e9bb2a72a5df9db44"
+      "git_hash": "feature/visualization-resource"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "46f5aa4d1aaa44f430360db22ce3c88e24b2f365"
+      "git_hash": "c55102760f91727bde501ca8f6cdd3117165ea19"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "fbebb3ca1c63e8e9433afa5cedf564627f90faec"
+      "git_hash": "5ee1a60f47a75013b489eedf7c8dd03bc6e514a4"
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "943f15a4d1191223b359613874218008833075ea"
+      "git_hash": "30d1144e7e80728c4a7e947b68a76e6e3b2729b7"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "0628c770a1bd87ed40a2ba32667524f2af8c4c44"
+      "git_hash": "19b580548b9f80a794e6e24cbaecae1f9f846d1a"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "2d65cbe30325ab25c52d19f9fe96179fec7147a0"
+      "git_hash": "d2db38c335c5c9cb9624cc563b7989c031283f1c"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "c55585fb3c2e3c281d911bd45a0fe4e4ff3173a5"
+      "git_hash": "49f3335020ae7a19d9713a9cad273d446195c979"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "ALS_4547_Security_findings"
+      "git_hash": "ALS_4551_http_headers"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,15 +3,15 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "v2.6.1"
+      "git_hash": "release"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "v2.2.0"
+      "git_hash": "genomic-v2"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "v3.0.3"
+      "git_hash": "release"
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,11 +3,11 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "b8bb72ce62b18069c65092ba9004bee6e92f669e"
+      "git_hash": "69f7ac6063a5b31e738d2d7c9a2702923eecbd75"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "49f3335020ae7a19d9713a9cad273d446195c979"
+      "git_hash": "c55585fb3c2e3c281d911bd45a0fe4e4ff3173a5"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,11 +11,11 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "87bfe5808fc26542b27d3b10a6a626fc060e6fda"
+      "git_hash": "4fc9a242e02ff091d5c89065307123d8fe327523"
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "d7f4cc4c5d08f08f28ee6e846e67abe8f9315d2e"
+      "git_hash": "dcf20aadc499f7536b9f60fb6e1ddfcbede4b68f"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "96b966a8cc08caec6d0b1e630f488c8a3a746d58"
+      "git_hash": "f3bfdebb74da890e22e9451fcefdf98d5cf874f6"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "49502dc45b931ffcb8d34ea59c44df4c9fa2a17d"
+      "git_hash": "96b966a8cc08caec6d0b1e630f488c8a3a746d58"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "1ef6d36bb675e587f95c8eed09f8a8ee7b8df55b"
+      "git_hash": "1d95752ca3447d47d30ec1991df746de51758705"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "release"
+      "git_hash": "v2.19.1"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,23 +3,23 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "df81a5fb75e4e997080816b0960ff3a9caf836b5"
+      "git_hash": "df5e128f140db7b05a0c8c1e9bb2a72a5df9db44"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "c55102760f91727bde501ca8f6cdd3117165ea19"
+      "git_hash": "46f5aa4d1aaa44f430360db22ce3c88e24b2f365"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "5ee1a60f47a75013b489eedf7c8dd03bc6e514a4"
+      "git_hash": "fbebb3ca1c63e8e9433afa5cedf564627f90faec"
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "ALS_4551_http_headers"
+      "git_hash": "e1e200e5ad1b0ae6fdcdfcce8d8f6c3c8a134d2c"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "ALS_4551_http_headers"
+      "git_hash": "a82637ba9c9d546e25344f75db76467e5b91f339"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "a4524b72105dcafceaac41f1d5bcce75e2e5f5fd"
+      "git_hash": "9c759024838b3cdb118ff4559c9a0a8844e1b3f2"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "7141aff314512bc927e971c0d4a9ce90d0be6aa1"
+      "git_hash": "6a0467b61af4cb8e543edac247c18f8ec281fce0"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "d30d6a34976c88e465d289bb9034b89013a6c22a"
+      "git_hash": "a9bb7feb94d499d7f83f03eac6f10b23e37a6ccc"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "d4838ca93815ca8aa8d8be821bb36ba1e468ba7c"
+      "git_hash": "a36e8bc84abc06241a85e18a49ac1ceba512bcb5"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "ALS-6098"
+      "git_hash": "feature/java-21"
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "94a8a35a5e2b56b4dca080f0b493d898767ed252"
+      "git_hash": "64cccb8511aa2d6fa8b977774c64ddf063e840ea"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "514acd6866e360bf3ed5c9796e09ce79efa93666"
+      "git_hash": "49502dc45b931ffcb8d34ea59c44df4c9fa2a17d"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,11 +15,11 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "a9bb7feb94d499d7f83f03eac6f10b23e37a6ccc"
+      "git_hash": "6a0467b61af4cb8e543edac247c18f8ec281fce0"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "a36e8bc84abc06241a85e18a49ac1ceba512bcb5"
+      "git_hash": "d4838ca93815ca8aa8d8be821bb36ba1e468ba7c"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "a36e8bc84abc06241a85e18a49ac1ceba512bcb5"
+      "git_hash": "662df320cf9126d3b7501309f562a3218f7773da"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,11 +15,11 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "96e1362f63871ef1a8280b5935455123facd606a"
+      "git_hash": "ALS_4551_http_headers"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "0d59e72cdfa41c42c328890fd82a71e9d9cb2e5f"
+      "git_hash": "ALS_4551_http_headers"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "f0f54d2763740c5158de926ce04b3f3c539a664b"
+      "git_hash": "4c6d6ac64764de4d7350431ae8d1d32bd0a9293d"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "69f7ac6063a5b31e738d2d7c9a2702923eecbd75"
+      "git_hash": "682401d96b15803140259af691528c933444bf8a"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "212ca22bf29effb306349596b5d15c4aaef29734"
+      "git_hash": "31fedc4701994ff674b3eba50cd385132515c109"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "feature/java-21"
+      "git_hash": "feature/java-21-Merge-Fence"
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "Facet_Loader"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",
-      "git_hash": "release"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "d71c672ae5c0bd0bd603845ad4cf9c9809db421f"
+      "git_hash": "1ef6d36bb675e587f95c8eed09f8a8ee7b8df55b"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,11 +15,11 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "e1e200e5ad1b0ae6fdcdfcce8d8f6c3c8a134d2c"
+      "git_hash": "943f15a4d1191223b359613874218008833075ea"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "0628c770a1bd87ed40a2ba32667524f2af8c4c44"
+      "git_hash": "a06eee0a99a9b3267cad5cbb864ee0f6be299348"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "1e79eebc47e84b6b60451bd1b61dd5a05c6ad3db"
+      "git_hash": "87bfe5808fc26542b27d3b10a6a626fc060e6fda"
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "feature/java-21-Merge-Fence"
+      "git_hash": "release"
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -27,7 +27,7 @@
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "ALS-8903"
+      "git_hash": "main"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,11 +15,11 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "ALS_4551_http_headers"
+      "git_hash": "96e1362f63871ef1a8280b5935455123facd606a"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "19b580548b9f80a794e6e24cbaecae1f9f846d1a"
+      "git_hash": "0d59e72cdfa41c42c328890fd82a71e9d9cb2e5f"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "main"
+      "git_hash": "ALS-8227"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "d4838ca93815ca8aa8d8be821bb36ba1e468ba7c"
+      "git_hash": "7b229a82777fc109651ddde99cf9fc565a8ad868"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "d2db38c335c5c9cb9624cc563b7989c031283f1c"
+      "git_hash": "004e326118b61e568df21aa80756b50e2712597d"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "ALS-8712"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
@@ -27,7 +27,7 @@
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "Generate-Ideal-Ingest-CSV"
+      "git_hash": "main"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "f3bfdebb74da890e22e9451fcefdf98d5cf874f6"
+      "git_hash": "0ec4478c999219c5b4a25aff913a96d7e3826eb3"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "fd0fb5acbb3d57b245300e587bd0cf16243ee13d"
+      "git_hash": "3fe1a5a57f9c0aafc907f8aae068e2ceb773bccb"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "9b45e324c39b446f5c7eb710d32316f4ba02b56c"
+      "git_hash": "660b59956c80d66a8dd19beeed1a0dad017c1a8b"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -13,13 +13,17 @@
       "project_job_git_key":"PSAMA",
       "git_hash": "release"
     },{
-      "project_name": "PIC-SURE-CORE-FRONTEND Build",
-      "project_job_git_key":"PSHU",
-      "git_hash": "v2.14.0"
+      "project_name": "PIC-SURE-Database-Migrations",
+      "project_job_git_key":"PSM",
+      "git_hash": "main"
     },{
-      "project_name": "project-specific-ui",
-      "project_job_git_key":"PSU",
-      "git_hash": "master"
+      "project_name": "PIC-SURE-Frontend Build",
+      "project_job_git_key":"PSF",
+      "git_hash": "release"
+    },{
+      "project_name": "PIC-SURE Dictionary",
+      "project_job_git_key":"DICTIONARY",
+      "git_hash": "main"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -26,7 +26,7 @@
       "git_hash": "ALS-5375"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
-      "project_job_git_key":"DICTIONARY-ETL",
+      "project_job_git_key":"DICTIONARY_ETL",
       "git_hash": "ALS-6816"
     }
   ]

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,23 +3,23 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "da6c12b456d85b4a8ba621d2baf7c0474ce3f225"
+      "git_hash": "f35255190e9b5f007c3033d61e53d4cf3dc64cdb"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "1885753b1cec7ed0239d3dd75c7a3ee980d7a969"
+      "git_hash": "c55102760f91727bde501ca8f6cdd3117165ea19"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "66f511ad144a2d991d2f6511f5f6539ac9aadcfd"
+      "git_hash": "5ee1a60f47a75013b489eedf7c8dd03bc6e514a4"
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "7141aff314512bc927e971c0d4a9ce90d0be6aa1"
+      "git_hash": "b8f0af6de495333bb5f4f9ff94fa378cc8afc14e"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "d4838ca93815ca8aa8d8be821bb36ba1e468ba7c"
+      "git_hash": "a9a8c47ff7f020b166a55828a5559eb3bf3ae450"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "1e670fe0b9ff6b47032a44bce8d7966ae8a79c00"
+      "git_hash": "b87a436614f5c3c3bfada51baa8a50d7460dacb7"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,11 +3,11 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "ALS-5375"
+      "git_hash": "release"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "ALS-6816"
+      "git_hash": "genomic-v2"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",
-      "git_hash": "ALS-5375-Dictionary-Resource"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",
@@ -23,11 +23,11 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "ALS-5375"
+      "git_hash": "release"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "ALS-6816"
+      "git_hash": "main"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "f2e5b4378754a0ab83c4104844df07e4f21abbb9"
+      "git_hash": "0c0ecfb07827247ced9fa26cc2d998c64e1ab14a"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "49f3335020ae7a19d9713a9cad273d446195c979"
+      "git_hash": "c55585fb3c2e3c281d911bd45a0fe4e4ff3173a5"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "59785065167edd60e666ad258357b46d05265a5f"
+      "git_hash": "a0a2f4f383ecaf65772f2513858c494f4271dd5b"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "5a3350f9fc4651c871375de3980bb4eea5a3169a"
+      "git_hash": "e33a7807be69175012ad161ea4da3bee2ae8928a"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "ALS-8227"
+      "git_hash": "release"
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",
@@ -19,7 +19,7 @@
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",
-      "git_hash": "ALS-7060"
+      "git_hash": "release"
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "genomic-v2"
+      "git_hash": "v2.6.0"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,23 +3,23 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "master"
+      "git_hash": "release/0006"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "master"
+      "git_hash": "release/0005"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "master"
+      "git_hash": "release/0002"
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "master"
+      "git_hash": "release/0008"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "master"
+      "git_hash": "release/0001"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "release"
+      "git_hash": "Update-WildFly"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "Dockerize-Maven-Install"
+      "git_hash": "genomic-v2"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
@@ -23,7 +23,7 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "release"
+      "git_hash": "fix-all-in-one-dictionary-db"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,11 +3,11 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "004e326118b61e568df21aa80756b50e2712597d"
+      "git_hash": "25896ccd22931b1aeb3083b818356d220c47dbb9"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "12985c74b699d1ae02b1fd468573cf1b0b080868"
+      "git_hash": "c55102760f91727bde501ca8f6cdd3117165ea19"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
@@ -15,11 +15,11 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "a9bb7feb94d499d7f83f03eac6f10b23e37a6ccc"
+      "git_hash": "30d1144e7e80728c4a7e947b68a76e6e3b2729b7"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "4c6d6ac64764de4d7350431ae8d1d32bd0a9293d"
+      "git_hash": "19b580548b9f80a794e6e24cbaecae1f9f846d1a"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "v2.0.0"
+      "git_hash": "ALS-6098"
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "d44bf0674f4ec041fcaae62fbe496f006327cf37"
+      "git_hash": "df81a5fb75e4e997080816b0960ff3a9caf836b5"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "release"
+      "git_hash": "v2.0.1"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -23,7 +23,7 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "main"
+      "git_hash": "ALS-6816"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "ba379f42c61b7cd516196b3fb138c1e52ebfe454"
+      "git_hash": "514acd6866e360bf3ed5c9796e09ce79efa93666"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,11 +11,11 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "ALS-6103"
+      "git_hash": "v3.0.3"
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "ALS-6103"
+      "git_hash": "v2.14.0"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "release"
+      "git_hash": "ALS-8227"
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,7 +15,7 @@
     },{
       "project_name": "PIC-SURE-CORE-FRONTEND Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "release/0008"
+      "git_hash": "ALS-5138-Banner-Improvements"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "662df320cf9126d3b7501309f562a3218f7773da"
+      "git_hash": "a0a2f4f383ecaf65772f2513858c494f4271dd5b"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "011d19ddcfffff6609b896258d93c7ae2c5c11eb"
+      "git_hash": "662df320cf9126d3b7501309f562a3218f7773da"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "b57a1759f45008749e06d3ba15f45e55b5b32ae1"
+      "git_hash": "d71c672ae5c0bd0bd603845ad4cf9c9809db421f"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "682401d96b15803140259af691528c933444bf8a"
+      "git_hash": "da6c12b456d85b4a8ba621d2baf7c0474ce3f225"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "4fc9a242e02ff091d5c89065307123d8fe327523"
+      "git_hash": "f612d484290d0495989e287714d8c2db188b7013"
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "454958063815a1dfa713a52674111249bfcd41ad"
+      "git_hash": "50c2471d82333601a6af12ca3610774892bea42f"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,23 +3,23 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "b8bb72ce62b18069c65092ba9004bee6e92f669e"
+      "git_hash": "69f7ac6063a5b31e738d2d7c9a2702923eecbd75"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "49f3335020ae7a19d9713a9cad273d446195c979"
+      "git_hash": "c55585fb3c2e3c281d911bd45a0fe4e4ff3173a5"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "1e79eebc47e84b6b60451bd1b61dd5a05c6ad3db"
+      "git_hash": "87bfe5808fc26542b27d3b10a6a626fc060e6fda"
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "d30d6a34976c88e465d289bb9034b89013a6c22a"
+      "git_hash": "94a8a35a5e2b56b4dca080f0b493d898767ed252"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "d4838ca93815ca8aa8d8be821bb36ba1e468ba7c"
+      "git_hash": "0af3ad5ad479b5c5486f4c63291adc7458eeb30f"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "f612d484290d0495989e287714d8c2db188b7013"
+      "git_hash": "66f511ad144a2d991d2f6511f5f6539ac9aadcfd"
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",

--- a/build-spec.json
+++ b/build-spec.json
@@ -15,11 +15,11 @@
     },{
       "project_name": "PIC-SURE-HPDS-UI Build",
       "project_job_git_key":"PSHU",
-      "git_hash": "6a0467b61af4cb8e543edac247c18f8ec281fce0"
+      "git_hash": "a9bb7feb94d499d7f83f03eac6f10b23e37a6ccc"
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "d4838ca93815ca8aa8d8be821bb36ba1e468ba7c"
+      "git_hash": "7b229a82777fc109651ddde99cf9fc565a8ad868"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "test-migration"
+      "git_hash": "master"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -19,7 +19,7 @@
     },{
       "project_name": "project-specific-ui",
       "project_job_git_key":"PSU",
-      "git_hash": "c9614c46bbcd06d44294cd1dbd75d3ca670987b6"
+      "git_hash": "011d19ddcfffff6609b896258d93c7ae2c5c11eb"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "c55585fb3c2e3c281d911bd45a0fe4e4ff3173a5"
+      "git_hash": "61f34b4d55f843621f87877ef1c0b852a0175d15"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "ALS-10712"
+      "git_hash": "George_Test"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
@@ -27,7 +27,7 @@
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "ALS-10712"
+      "git_hash": "George_Test"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "release"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "release"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",
@@ -27,7 +27,7 @@
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "Facet_Loader"
+      "git_hash": "main"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -23,7 +23,7 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "meilisearch"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,15 +3,15 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "ALS-10712"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "ALS-10712"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "ALS-10712"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "main"
+      "git_hash": "ALS-10712"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "main"
+      "git_hash": "ALS-10712"
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",

--- a/build-spec.json
+++ b/build-spec.json
@@ -23,7 +23,7 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "main"
+      "git_hash": "meilisearch"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",

--- a/build-spec.json
+++ b/build-spec.json
@@ -27,7 +27,7 @@
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "main"
+      "git_hash": "ALS-10712"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "George_Test"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
@@ -27,7 +27,7 @@
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "George_Test"
+      "git_hash": "main"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "main"
+      "git_hash": "ALS-10712"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,7 +7,7 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "main"
+      "git_hash": "pic_sure_api_rewrite_p3"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
@@ -24,7 +24,7 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "main"
+      "git_hash": "pic_sure_api_rewrite_p3"
     },{
       "project_name": "PIC-SURE Logging",
       "project_job_git_key":"PSL",

--- a/build-spec.json
+++ b/build-spec.json
@@ -24,7 +24,7 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "main"
+      "git_hash": "ALS-12219"
     },{
       "project_name": "PIC-SURE Logging",
       "project_job_git_key":"PSL",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,15 +3,15 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "feature/configuration2-george-test"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "v4.13.0"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "ALS-10196-fix-roles"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",
@@ -20,19 +20,19 @@
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",
-      "git_hash": "v3.0.0"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "v1.8.2"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Logging",
       "project_job_git_key":"PSL",
-      "git_hash": "v1.0.3"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "v1.1.0"
+      "git_hash": "main"
     }
   ]
 }

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,12 +11,12 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "main"
+      "git_hash": "pic_sure_api_rewrite_p3"
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",
       "project_name": "Baseline",
-      "git_hash": "main"
+      "git_hash": "pic_sure_api_rewrite_p3"
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "feature/configuration2"
+      "git_hash": "feature/configuration2-george-test"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "pic_sure_api_rewrite"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -1,37 +1,20 @@
 {
   "application": [
     {
-      "project_name": "PIC-SURE-API Build",
-      "project_job_git_key":"PSA",
-      "git_hash": "pic_sure_api_rewrite"
+      "project_name": "PIC-SURE Monorepo",
+      "project_job_git_key": "MONOREPO",
+      "git_hash": "pic_sure_api_mono_repo"
     },{
-      "project_name": "PIC-SURE-HPDS Build",
-      "project_job_git_key":"PSH",
-      "git_hash": "pic_sure_api_rewrite"
-    },{
-      "project_name": "PIC-SURE Auth Micro-App Build",
-      "project_job_git_key":"PSAMA",
+      "project_name": "PIC-SURE-Frontend Build",
+      "project_job_git_key": "PSF",
       "git_hash": "pic_sure_api_rewrite"
     },{
       "project_name": "PIC-SURE-Database-Migrations",
-      "project_job_git_key":"PSM",
-      "project_name": "Baseline",
-      "git_hash": "pic_sure_api_rewrite"
-    },{
-      "project_name": "PIC-SURE-Frontend Build",
-      "project_job_git_key":"PSF",
-      "git_hash": "pic_sure_api_rewrite"
-    },{
-      "project_name": "PIC-SURE Dictionary",
-      "project_job_git_key":"DICTIONARY",
-      "git_hash": "pic_sure_api_rewrite"
-    },{
-      "project_name": "PIC-SURE Logging",
-      "project_job_git_key":"PSL",
+      "project_job_git_key": "PSM",
       "git_hash": "pic_sure_api_rewrite"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
-      "project_job_git_key":"DICTIONARY_ETL",
+      "project_job_git_key": "DICTIONARY_ETL",
       "git_hash": "main"
     }
   ]

--- a/build-spec.json
+++ b/build-spec.json
@@ -11,7 +11,7 @@
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "v4.2.2"
+      "git_hash": "ALS-10196-fix-roles"
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",

--- a/build-spec.json
+++ b/build-spec.json
@@ -28,7 +28,7 @@
     },{
       "project_name": "PIC-SURE Logging",
       "project_job_git_key":"PSL",
-      "git_hash": "main"
+      "git_hash": "pic_sure_api_rewrite_p3"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",

--- a/build-spec.json
+++ b/build-spec.json
@@ -20,7 +20,7 @@
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",
-      "git_hash": "main"
+      "git_hash": "pic_sure_api_rewrite"
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "main"
+      "git_hash": "pic_sure_api_rewrite"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",

--- a/build-spec.json
+++ b/build-spec.json
@@ -16,7 +16,7 @@
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",
       "project_name": "Baseline",
-      "git_hash": "v1.0.3"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,7 +3,7 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "main"
+      "git_hash": "pic_sure_api_rewrite"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
@@ -24,7 +24,7 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "ALS-12219"
+      "git_hash": "main"
     },{
       "project_name": "PIC-SURE Logging",
       "project_job_git_key":"PSL",

--- a/build-spec.json
+++ b/build-spec.json
@@ -7,16 +7,16 @@
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "pic_sure_api_rewrite_p3"
+      "git_hash": "pic_sure_api_rewrite"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "pic_sure_api_rewrite_p3"
+      "git_hash": "pic_sure_api_rewrite"
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",
       "project_name": "Baseline",
-      "git_hash": "pic_sure_api_rewrite_p3"
+      "git_hash": "pic_sure_api_rewrite"
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",
@@ -24,11 +24,11 @@
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "pic_sure_api_rewrite_p3"
+      "git_hash": "pic_sure_api_rewrite"
     },{
       "project_name": "PIC-SURE Logging",
       "project_job_git_key":"PSL",
-      "git_hash": "pic_sure_api_rewrite_p3"
+      "git_hash": "pic_sure_api_rewrite"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",

--- a/build-spec.json
+++ b/build-spec.json
@@ -3,31 +3,36 @@
     {
       "project_name": "PIC-SURE-API Build",
       "project_job_git_key":"PSA",
-      "git_hash": "main"
+      "git_hash": "feature/configuration2"
     },{
       "project_name": "PIC-SURE-HPDS Build",
       "project_job_git_key":"PSH",
-      "git_hash": "main"
+      "git_hash": "v4.13.0"
     },{
       "project_name": "PIC-SURE Auth Micro-App Build",
       "project_job_git_key":"PSAMA",
-      "git_hash": "main"
+      "git_hash": "v4.2.2"
     },{
       "project_name": "PIC-SURE-Database-Migrations",
       "project_job_git_key":"PSM",
-      "git_hash": "main"
+      "project_name": "Baseline",
+      "git_hash": "v1.0.3"
     },{
       "project_name": "PIC-SURE-Frontend Build",
       "project_job_git_key":"PSF",
-      "git_hash": "main"
+      "git_hash": "v3.0.0"
     },{
       "project_name": "PIC-SURE Dictionary",
       "project_job_git_key":"DICTIONARY",
-      "git_hash": "main"
+      "git_hash": "v1.8.2"
+    },{
+      "project_name": "PIC-SURE Logging",
+      "project_job_git_key":"PSL",
+      "git_hash": "v1.0.3"
     },{
       "project_name": "PIC-SURE Dictionary ETL",
       "project_job_git_key":"DICTIONARY_ETL",
-      "git_hash": "main"
+      "git_hash": "v1.1.0"
     }
   ]
 }


### PR DESCRIPTION
## What this does

Restructures `build-spec.json` for the monorepo consolidation — pairs with `hms-dbmi/pic-sure-all-in-one#253` (the `PIC-SURE Pipeline` collapse); **land the two together**, since the pipeline's `MONOREPO` key lookup and this schema are a matched pair.

- The per-service entries (`PSA`, `PSH`, `PSAMA`, `DICTIONARY`, `PSL`) collapse into one entry: `MONOREPO` → `pic_sure_api_mono_repo` (the ref every monorepo service job builds)
- Genuinely separate repos keep their entries: `PSF` (frontend), `PSM` (migrations), `DICTIONARY_ETL`
- Fixes the latent bug where the Migrations entry declared `project_name` twice (the second silently overwrote the first)

A release now pins one monorepo ref (branch/tag/hash) — the single-platform-release model.

Note: this PR's base is `pic_sure_api_rewrite`; the branch was cut from `george`, so the diff may include commits `george` carries beyond the base.